### PR TITLE
Simplify SDP index mapping

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -212,8 +212,6 @@ end
 # Vectorized length for matrix dimension n
 sympackedlen(n) = div(n * (n + 1), 2)
 
-matindices(n::Integer) = LinearIndices(trues(n,n))[findall(LinearAlgebra.tril(trues(n,n)))]
-
 function _optimize!(dest::Optimizer, src::OptimizerCache)
     MOI.empty!(dest)
     TimerOutputs.reset_timer!()
@@ -281,8 +279,7 @@ function _optimize!(dest::Optimizer, src::OptimizerCache)
     for psc in psc_s
         tri_len = length(psc)
         sq_side = MOI.Utilities.side_dimension_for_vectorized_dimension(tri_len)
-        mat_inds = matindices(sq_side)
-        push!(con.sdpcone, SDPSet(psc, mat_inds, tri_len, sq_side))
+        push!(con.sdpcone, SDPSet(psc, tri_len, sq_side))
     end
     dest.cones = ConeData(
         psc_s,

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -5,21 +5,7 @@ function preprocess!(aff::AffineSets, conic_sets::ConicSets)
         all_cone_vars = Int[]
         for (idx, sdp) in enumerate(conic_sets.sdpcone)
             M = zeros(Int, sdp.sq_side, sdp.sq_side)
-            iv = conic_sets.sdpcone[idx].vec_i
-            im = conic_sets.sdpcone[idx].mat_i
-            for i in eachindex(iv)
-                M[im[i]] = iv[i]
-            end
-            X = LinearAlgebra.Symmetric(M, :L)
-
-            n = size(X)[1] # columns or line
-            cont = 1
-            sdp_vars = zeros(Int, div(sdp.sq_side*(sdp.sq_side+1), 2))
-            for j in 1:n, i in j:n
-                sdp_vars[cont] = X[i, j]
-                cont += 1
-            end
-            append!(all_cone_vars, sdp_vars)
+            append!(all_cone_vars, conic_sets.sdpcone[idx].vec_i)
         end
         for (idx, soc) in enumerate(conic_sets.socone)
             soc_vars = copy(soc.idx)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -43,7 +43,6 @@ end
 
 mutable struct SDPSet
     vec_i::Vector{Int}
-    mat_i::Vector{Int}
     tri_len::Int
     sq_side::Int
 end


### PR DESCRIPTION
I was a bit worried at first when reading it because `mapindices` create columnwise **lower**-triangular indices while the MOI convention is columnwise **upper**-triangular.
Then it seems that the way it's used just goes back and forth and at it end it just gives the MOI variable indices ? I might be wrong but let's try (I need to get in the plane so no time to test :laughing: )