### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1,8 +1,6 @@
-const MOI = MathOptInterface
+MOI.Utilities.@product_of_sets(_Zeros, MOI.Zeros)
 
-MOI.Utilities.@product_of_sets(Zeros, MOI.Zeros)
-
-MOI.Utilities.@product_of_sets(Nonpositives, MOI.Nonpositives)
+MOI.Utilities.@product_of_sets(_Nonpositives, MOI.Nonpositives)
 
 MOI.Utilities.@struct_of_constraints_by_set_types(
     StructCache,
@@ -25,7 +23,7 @@ const OptimizerCache{T} = MOI.Utilities.GenericModel{
                 MOI.Utilities.OneBasedIndexing,
             },
             Vector{T},
-            Zeros{T},
+            _Zeros{T},
         },
         MOI.Utilities.MatrixOfConstraints{
             T,
@@ -35,7 +33,7 @@ const OptimizerCache{T} = MOI.Utilities.GenericModel{
                 MOI.Utilities.OneBasedIndexing,
             },
             Vector{T},
-            Nonpositives{T},
+            _Nonpositives{T},
         },
         MOI.Utilities.VectorOfConstraints{
             MOI.VectorOfVariables,
@@ -55,8 +53,8 @@ end
 
 mutable struct Optimizer <: MOI.AbstractOptimizer
     cones::Union{Nothing, ConeData}
-    zeros::Union{Nothing, Zeros{Float64}}
-    nonps::Union{Nothing, Nonpositives{Float64}}
+    zeros::Union{Nothing, _Zeros{Float64}}
+    nonps::Union{Nothing, _Nonpositives{Float64}}
     sol::Result
     options::Options
 end

--- a/src/ProxSDP.jl
+++ b/src/ProxSDP.jl
@@ -4,7 +4,7 @@ using PrecompileTools: @setup_workload, @compile_workload
 
 import Arpack
 import KrylovKit
-import MathOptInterface
+import MathOptInterface as MOI
 import TimerOutputs
 import TimerOutputs: @timeit
 


### PR DESCRIPTION
```julia
  1 dependency had output during precompilation:
┌ ProxSDP
│  WARNING: using JuMP.Nonpositives in module ProxSDP conflicts with an existing identifier.
│  WARNING: using JuMP.Zeros in module ProxSDP conflicts with an existing identifier.
│   29.489161 seconds (123.31 M allocations: 8.369 GiB, 3.33% gc time, 15.12% compilation time)
│  rank = model.moi_backend.optimizer.model.optimizer.sol.final_rank = 3
│   25.322369 seconds (103.47 M allocations: 7.041 GiB, 1.27% gc time)
│  rank = model.moi_backend.optimizer.model.optimizer.sol.final_rank = 4
│    0.437748 seconds (126.89 k allocations: 80.031 MiB, 2.28% gc time)
│  rank = model.moi_backend.optimizer.model.optimizer.sol.final_rank = 2
└ 
```