### PR TITLE
Update KrylovKit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 Arpack = "0.3.2, 0.5.1"
-KrylovKit = "0.5.2"
+KrylovKit = "0.5.2 - 0.9"
 MathOptInterface = "1"
 PrecompileTools = "1.1.0"
 TimerOutputs = "0.5.0"


### PR DESCRIPTION
All tests are still passing with the newest version of KrylovKit - the one currently used is three years old, which I just noted when installation of ProxSDP downgraded a large number of other packages.